### PR TITLE
fix: 空文字の要素を削除するように変更

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -410,7 +410,7 @@ mod tests {
                   b!(
                     "set",
                     vec![
-                      b!("\"tmp\""),
+                      b!(str!("tmp")),
                       b!(
                         "ifn0",
                         vec![
@@ -475,7 +475,7 @@ mod tests {
 
   #[test]
   fn split_string() {
-    let result = execute(*b!("split str", vec![b!("\"abc def ghi\""), b!("\" \"")]), Box::new(|_| panic!()));
+    let result = execute(*b!("split str", vec![b!(str!("abc def ghi")), b!(str!(" "))]), Box::new(|_| panic!()));
 
     assert_eq!(
       result,
@@ -489,7 +489,7 @@ mod tests {
 
   #[test]
   fn split_string_per_char() {
-    let result = execute(*b!("split str", vec![b!("\"abc\""), b!("\"\"")]), Box::new(|_| panic!()));
+    let result = execute(*b!("split str", vec![b!(str!("abc")), b!(str!(""))]), Box::new(|_| panic!()));
 
     assert_eq!(
       result,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -129,7 +129,7 @@ fn predefined_procs() -> HashMap<String, BehaviorOrVar> {
   add_map!("read line", { Ok(Literal::String(exec_env.read_line())) }, exec_env, args;);
 
   add_map!("split str", {
-    Ok(Literal::List(origin.split(&spliter).map(|str|Literal::String(str.to_owned())).filter(|str| str.clone() != Literal::String("".to_string())).collect()))
+    Ok(Literal::List(origin.split(&spliter).filter(|str| !str.is_empty()).map(|str|Literal::String(str.to_owned())).collect()))
   }; origin: str, spliter: str);
   add_map!("str to bytes", {
     Ok(Literal::List(string.as_bytes().iter().map(|b|Literal::Int((*b).into())).collect()))

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -129,7 +129,7 @@ fn predefined_procs() -> HashMap<String, BehaviorOrVar> {
   add_map!("read line", { Ok(Literal::String(exec_env.read_line())) }, exec_env, args;);
 
   add_map!("split str", {
-    Ok(Literal::List(origin.split(&spliter).map(|str|Literal::String(str.to_owned())).collect()))
+    Ok(Literal::List(origin.split(&spliter).map(|str|Literal::String(str.to_owned())).filter(|str| str.clone() != Literal::String("".to_string())).collect()))
   }; origin: str, spliter: str);
   add_map!("str to bytes", {
     Ok(Literal::List(string.as_bytes().iter().map(|b|Literal::Int((*b).into())).collect()))
@@ -471,6 +471,34 @@ mod tests {
     );
 
     assert!(result.is_err());
+  }
+
+  #[test]
+  fn split_string() {
+    let result = execute(*b!("split str", vec![b!("\"abc def ghi\""), b!("\" \"")]), Box::new(|_| panic!()));
+
+    assert_eq!(
+      result,
+      Ok(Literal::List(vec![
+        Literal::String("abc".to_string()),
+        Literal::String("def".to_string()),
+        Literal::String("ghi".to_string())
+      ]))
+    )
+  }
+
+  #[test]
+  fn split_string_per_char() {
+    let result = execute(*b!("split str", vec![b!("\"abc\""), b!("\"\"")]), Box::new(|_| panic!()));
+
+    assert_eq!(
+      result,
+      Ok(Literal::List(vec![
+        Literal::String("a".to_string()),
+        Literal::String("b".to_string()),
+        Literal::String("c".to_string())
+      ]))
+    )
   }
 
   #[test]


### PR DESCRIPTION
close #9.
```
running 24 tests
test compile::tests::test_split_code ... ok
test compile::tests::check_find_blocks ... ok
test compile::tests::two_connect ... ok
test compile::tests::one_block ... ok
test compile::tests::one_block_complex ... ok
test executor::tests::split_string ... ok
test executor::tests::split_string_per_char ... ok
test executor::tests::simple_summing ... ok
test executor::tests::cannot_refer_inside ... ok
test executor::tests::too_much_args ... ok
test executor::tests::simple_export ... ok
test tests::a_plus_b ... ok
test tests::cmd ... ok
test executor::tests::fizzbuzz ... ok
test tests::defproc ... ok
test tests::lists ... ok
test executor::tests::fizzbuzz2 ... ok
test tests::modules ... ok
test tests::println ... ok
test tests::modules_err ... ok
test tests::fizzbuzz ... ok
test tests::string_bytes ... ok
test tests::recursion ... ok
test tests::substance ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```